### PR TITLE
Adding a .mailmap file to deduplicate contributor identities

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,10 @@
+Antoine Burie <antoine.burie@cs-soprasteria.com>       aburie-cs <antoine.burie@cs-soprasteria.com>
+Florian Douziech <florian.douziech@cs-soprasteria.com> Florian Douziech <76962513+fdouziech@users.noreply.github.com>
+Guylaine Prat <guylaine.prat@cs-soprasteria.com>       Guylaine Prat <guylaine.prat@csgroup.eu>
+Jonathan Guinet <jonathan.guinet@cs-soprasteria.com>   jguinet <jonathan.guinet@c-s.fr>
+Marine Bouchet <marine.bouchet@cs-soprasteria.com>     marinebcht <154510863+marinebcht@users.noreply.github.com>
+Paul Castillo <paul.castillo@cs-soprasteria.com>       paul-csgroup0411 <paul.castillo@cs-soprasteria.com>
+Sara Teraitetia <sara.teraitetia@cs-soprasteria.com>   Sara TERAITETIA <sara.teraitetia@csgroup.eu>
+Sara Teraitetia <sara.teraitetia@cs-soprasteria.com>   steraite <72130836+steraite@users.noreply.github.com>
+Sébastien Dinot <sebastien.dinot@cs-soprasteria.com>   Sébastien Dinot <sdinot@errogol.idsi0.si.c-s.fr>
+Sébastien Dinot <sebastien.dinot@cs-soprasteria.com>   Sébastien Dinot <sebastien.dinot@free.fr>


### PR DESCRIPTION
Thanks to the .mailmap file, Git and GitHub display only a single identity for each contributor in the logs and statistics.

For example, the three commit authors listed below:

* John Doe <john@workstation.local.acme.com>
* John Doe <john.doe@acme.com>
* John Doe <john.doe@acme.co.uk>

may be grouped into a single entry in the logs displayed by Git:

* John Doe <john.doe@acme.com>